### PR TITLE
Update `lambda_http` and `tower-http`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["axum", "lambda", "tower", "aws"]
 
 [dependencies]
 axum = "0.6"
-lambda_http = "0.7"
+lambda_http = "0.8"
 hyper = "0.14"
 bytes = "1"
 http = "0.2"
@@ -23,7 +23,7 @@ tower-service = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt"] }
-tower-http = { version = "0.3", features = ["cors", "compression-gzip", "compression-deflate", "trace"] }
+tower-http = { version = "0.4", features = ["cors", "compression-gzip", "compression-deflate", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ where
 
     fn call(&mut self, req: lambda_http::Request) -> Self::Future {
         let uri = req.uri().clone();
-        let rawpath = req.raw_http_path();
+        let rawpath = req.raw_http_path().to_owned();
         let (mut parts, body) = req.into_parts();
         let body = match body {
             lambda_http::Body::Empty => axum::body::Body::default(),


### PR DESCRIPTION
This PR updates the `lambda_http` crate and the `tower-http` dev dependency.