### PR TITLE
Fix lambda payload format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,20 @@ Check out `examples/main.rs`: running in debug mode runs a hyper server, and bui
 
 ### Testing out the Lambda runtime locally
 
-I have also provided an example Dockerfile & python script for locally spinning up a lambda runtime:
-```
+There is an example Dockerfile for locally spinning up a lambda runtime:
+
+```terminal
 cargo build --release --example main
 docker build . -t lambda-test
 docker run -p 9000:8080 lambda-test
-python test_lambda_runtime
+```
+
+In `test-lambda-runtime/` there is a python script for testing and a Dockerfile for running it. 
+
+In another shell, from the root of this repository:
+
+```terminal
+cd test-lambda-runtime
+docker build . -t test_lambda_runtime
+docker run --network="host" test_lambda_runtime
 ```

--- a/test-lambda-runtime/Dockerfile
+++ b/test-lambda-runtime/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.9-slim as builder
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gcc
+
+COPY requirements.txt .
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+COPY . .
+
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /app/test_lambda_runtime.py .
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+EXPOSE 5000
+
+CMD ["python", "test_lambda_runtime.py"]

--- a/test-lambda-runtime/requirements.txt
+++ b/test-lambda-runtime/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/test-lambda-runtime/test_lambda_runtime.py
+++ b/test-lambda-runtime/test_lambda_runtime.py
@@ -4,23 +4,21 @@ import requests
 
 def mk_request(method="GET", body=None):
     return {
-        "body": json.dumps(body) if body else "",
         "headers": {
             "Accept": "*/*",
             "Content-Type": "application/json",
             "Host": "localhost:5000",
-            "User-Agent": "insomnia/2022.2.1",
+            "User-Agent": "insomnia/2022.2.1"
         },
-        "httpMethod": method,
-        "isBase64Encoded": False,
-        "multiValueHeaders": {
-            "Accept": "*/*",
-            "Content-Type": "application/json",
-            "Host": "localhost:5000",
-            "User-Agent": "insomnia/2022.2.1",
-        },
-        "path": "/",
         "queryStringParameters": {},
+        "requestContext": {
+            "http": {
+                "method": method,
+                "path": "/",
+            }
+        },
+        "body": json.dumps(body) if body else "",
+        "isBase64Encoded": False
     }
 
 


### PR DESCRIPTION
Cool project! I was excited to check it out, but then I ran into a deserialization error when trying to run the example with the Python test script.

I got things working when I edited the payload to be more in line with the [**Payload format version**](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) found in the Amazon API Gateway documentation.

This PR adapts the lambda payload in the Python test script to the format specified in the [Amazon API Gateway documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) and adds a Dockerfile for running the Python test script so that the `requests` dependencies will be in place without needing to install them.