### PR TITLE
chore: update lambda_http to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0]
+
+### Changed
+
+- Upgrade lambda_http to 0.14
+
 ## [0.8.0]
+
 ### Changed
 
 - Upgrade lambda_http to 0.13
 
 ## [0.7.0]
+
 ### Changed
 
 - Upgrade lambda_http to 0.11
 
 ## [0.6.0]
+
 ### Changed
 
 - Upgrade axum to 0.7, hyper to 1.0, and lambda_http to 0.9 versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["axum", "lambda", "tower", "aws"]
 
 [dependencies]
 axum = "0.7"
-lambda_http = "0.13"
+lambda_http = "0.14"
 hyper = "1.0"
 bytes = "1.5"
 http = "1"


### PR DESCRIPTION
We could get renovate very happy if we could update axum-aws-lambda with the new lambda_http.